### PR TITLE
added newer version of opencv-python to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pandas
 imageio
 imageio-ffmpeg
 tensorboard
+opencv-python==4.5.5.62


### PR DESCRIPTION
I needed a newer version of opencv-python to run introspection-train notebook